### PR TITLE
fix : switch to full Python 3.12 to avoid greenlet build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12
 
 WORKDIR /app
 


### PR DESCRIPTION
The previous image used python:3.12-slim on aarch64. But sqlmodel pulls in SQLAlchemy, which depends on greenlet.
For Python 3.12 on aarch64, greenlet has no prebuilt wheel, so pip tries to compile it from source.
The slim image lacks a compiler toolchain (gcc/g++), causing the Docker build to fail.

I decided to just use the full image instead of adding dependencies because I though it was more readable and I do not need to have a smaller image size at all cost.